### PR TITLE
Fix collect_fixtures

### DIFF
--- a/pytest_lazy_fixtures/fixture_collector.py
+++ b/pytest_lazy_fixtures/fixture_collector.py
@@ -12,7 +12,7 @@ def collect_fixtures(config: pytest.Config, items: list[pytest.Item]):
         for marker in item.own_markers:
             if marker.name != "parametrize":
                 continue
-            params = marker.args[1]
+            params = marker.args[1] if len(marker.args) > 1 else marker.kwargs["argvalues"]
             arg2fixturedefs = {}
             for param in params:
                 _, _arg2fixturedefs = get_fixturenames_closure_and_arg2fixturedefs(fm, item.parent, param)

--- a/tests/test_deadfixtures_support.py
+++ b/tests/test_deadfixtures_support.py
@@ -124,6 +124,50 @@ def test_lazy_fixture_callable_collected(pytester):
     assert result.ret == EXIT_CODE_SUCCESS, result.stdout
 
 
+def test_lazy_fixtures_collected_argvalues(pytester):
+    pytester.makepyfile(
+        """
+            import pytest
+            from pytest_lazy_fixtures import lf
+
+
+            @pytest.fixture
+            def some_fixture():
+                return 1
+
+            @pytest.mark.parametrize("value", argvalues=[lf("some_fixture")])
+            def test_simple(value):
+                assert 1 == value
+        """
+    )
+
+    result = pytester.runpytest("--dead-fixtures", plugins=("pytest_lazy_fixtures.plugin",))
+
+    assert result.ret == EXIT_CODE_SUCCESS, result.stdout
+
+
+def test_lazy_fixtures_collected_argnames_argvalues(pytester):
+    pytester.makepyfile(
+        """
+            import pytest
+            from pytest_lazy_fixtures import lf
+
+
+            @pytest.fixture
+            def some_fixture():
+                return 1
+
+            @pytest.mark.parametrize(argnames="value", argvalues=[lf("some_fixture")])
+            def test_simple(value):
+                assert 1 == value
+        """
+    )
+
+    result = pytester.runpytest("--dead-fixtures", plugins=("pytest_lazy_fixtures.plugin",))
+
+    assert result.ret == EXIT_CODE_SUCCESS, result.stdout
+
+
 def test_lazy_fixtures_collected_parametrized_fixture_simple(pytester):
     pytester.makepyfile(
         """


### PR DESCRIPTION
Fix collect_fixtures when pytest.mark.parametrize uses kwargs instead of args