### PR TITLE
Do not replace object if it's the same

### DIFF
--- a/pytest_lazy_fixtures/loader.py
+++ b/pytest_lazy_fixtures/loader.py
@@ -14,8 +14,12 @@ def load_lazy_fixtures(value, request: pytest.FixtureRequest):
         return value.load_fixture(request)
     # we need to check exact type
     if type(value) is dict:
-        return {load_lazy_fixtures(key, request): load_lazy_fixtures(val, request) for key, val in value.items()}
+        new_value = {load_lazy_fixtures(key, request): load_lazy_fixtures(val, request) for key, val in value.items()}
+        if new_value != value:
+            return new_value
     # we need to check exact type
     if type(value) in {list, tuple, set}:
-        return type(value)(load_lazy_fixtures(val, request) for val in value)
+        new_value = type(value)(load_lazy_fixtures(val, request) for val in value)
+        if new_value != value:
+            return new_value
     return value


### PR DESCRIPTION
In my understanding pytest will re-use the same fixture if the argument is the same.
The original pytest-lazy-fixture code will replace the dict (even when the values are the same).
```
a = {"1": "2"}
b = {"1": "2"}
print(a == b)  # True
print(a is b)  # False
```

This fixes an issue we had.
I'm not sure if editing the key/values inside the dict/list/... itself instead of replacing it is a better way to go though.